### PR TITLE
NEW Add wrapped function's original args and kwargs

### DIFF
--- a/tests/test_time_execution.py
+++ b/tests/test_time_execution.py
@@ -125,3 +125,33 @@ class TestTimeExecution(unittest.TestCase):
 
         for metric in self._query_influx(go.fqn):
             self.assertEqual(metric['exception_message'], 'test exception')
+
+    def test_time_execution_with_func_args(self):
+        param = 'foo'
+
+        def hook(response, exception, metric, func_args, func_kwargs):
+            self.assertEqual(func_args[0], param)
+            return metric
+
+        configure(backends=[self.backend], hooks=[hook])
+
+        @time_execution
+        def go(param1):
+            return '200 OK'
+
+        go(param)
+
+    def test_time_execution_with_func_kwargs(self):
+        param = 'foo'
+
+        def hook(response, exception, metric, func_args, func_kwargs):
+            self.assertEqual(func_kwargs['param1'], param)
+            return metric
+
+        configure(backends=[self.backend], hooks=[hook])
+
+        @time_execution
+        def go(param1):
+            return '200 OK'
+
+        go(param1=param)

--- a/time_execution/time_execution.py
+++ b/time_execution/time_execution.py
@@ -109,7 +109,9 @@ class time_execution(object):
             metadata = _apply_hooks(
                 response=response,
                 exception=exception,
-                metric=metric
+                metric=metric,
+                func_args=args,
+                func_kwargs=kwargs
             )
 
             metric.update(metadata)


### PR DESCRIPTION
This way an hook can access the original `args` and `kwargs` passed to the wrapped function.

A valid use case: for a `@time_execution` decorated `rest_framework.views.APIView` view (or a generic Django view), an hook can access the original `rest_framework.request.Request`.