### PR TITLE
FIX workaround TypeError in queue module

### DIFF
--- a/tests/test_threaded_backend.py
+++ b/tests/test_threaded_backend.py
@@ -118,10 +118,13 @@ class TestTimeExecution(TestBaseBackend):
             len(mocked_bulk_write.call_args[0][0])
         )
 
-    def test_queue_is_gone(self):
+    def test_worker_error(self):
         self.assertFalse(self.backend.thread is None)
-        self.backend._queue = None
-        time.sleep(2 * self.qtimeout)
+        # simulate TypeError in queue.get
+        with mock.patch.object(self.backend._queue, 'get', side_effect=TypeError):
+            # ensure worker loop repeat
+            time.sleep(2 * self.qtimeout)
+        # assert thread stopped
         self.assertTrue(self.backend.thread is None)
 
 

--- a/time_execution/backends/threaded.py
+++ b/time_execution/backends/threaded.py
@@ -75,14 +75,13 @@ class ThreadedBackend(BaseMetricsBackend):
                 send_metrics()
                 last_write = time.time()
                 metrics = []
-            if self._queue is None:
-                # queue may be gone with the main thread
-                logger.warning('queue is gone, stopping the worker')
-                break
             try:  # blocking get
                 name, data = self._queue.get(True, self.queue_timeout)
             except Empty:
                 continue
+            except TypeError as err:
+                logger.warning('stopping the worker due to %r', err)
+                break
             self.fetched_items += 1
             data['name'] = name
             metrics.append(data)


### PR DESCRIPTION
TypeError is actually raised inside the queue library, when time module is not available anymore due to interpreter shutdown.

This is a workaround, while the proper fix should be changing daemonic thread to the normal one and implement a proper shutdown.