### PR TITLE
Fix elasticsearch version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,11 @@ influx:
     - PRE_CREATE_DB=metrics
     - UDP_DB=metrics
 elasticsearch:
-  image: elasticsearch:2.1
+  image: elasticsearch:2
   ports:
     - "9200:9200"
 kibana:
-  image: kibana
+  image: kibana:4
   ports:
     - "5601:5601"
   links:

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,5 +1,5 @@
 influxdb>=2.11
-elasticsearch>=2.2.0
+elasticsearch>=2.2.0,<5
 pkgsettings>=0.9.2
 six>=1.10.0,<2.0.0
 fqn-decorators>=1.0.0,<2.0.0


### PR DESCRIPTION
Only ElasticSearch 2.1 is supported by timeexecution at the moment.

This change fixes versions of Kibana and Python elasticsearch package