### PR TITLE
Add flag to skip index + mapping creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -354,6 +354,13 @@ There is a Makefile with a few targets that we use often:
 
 ``make test`` command will run tests for the python versions specified in ``tox.ini`` spinning up all necessary services via docker.
 
+In some cases (on Ubuntu 18.04) the Elasticsearch Docker image might not be able to start and will exit with the following error::
+
+    max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
+    
+This can be solved by adding the following line to `/etc/sysctl.conf`::
+
+    vm.max_map_count=262144
 
 .. _Grafana: http://grafana.org/
 .. _Kibana: https://www.elastic.co/products/kibana

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -17,7 +17,7 @@ ELASTICSEARCH_HOST = os.getenv("ELASTICSEARCH_HOST")
 class TestConnectionErrors(TestBaseBackend):
     @mock.patch("time_execution.backends.elasticsearch.logger")
     def test_error_resilience(self, mocked_logger):
-        backend = ElasticsearchBackend(hosts=["non-existant-domain"])
+        backend = ElasticsearchBackend(hosts=["non-existent-domain"], max_retries=1)
         # ensure index and mapping setup failures are caught and logged
         self.assertEqual(2, len(mocked_logger.error.call_args_list))
         # ensure write failure is caught and logged

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -145,3 +145,10 @@ class TestTimeExecution(TestBaseBackend):
         with es_index_error_ctx:
             self.backend.bulk_write(metrics)
             mocked_logger.warning.assert_called_once_with("bulk_write metrics %r failure %r", metrics, transport_error)
+
+    @mock.patch("time_execution.backends.elasticsearch.ElasticsearchBackend._setup_mapping")
+    @mock.patch("time_execution.backends.elasticsearch.ElasticsearchBackend._setup_index")
+    def test_do_not_create_index(self, setup_index, setup_mapping):
+        ElasticsearchBackend(ELASTICSEARCH_HOST, index="unittest", create_index=False)
+        setup_index.assert_not_called()
+        setup_mapping.assert_not_called()

--- a/time_execution/backends/elasticsearch.py
+++ b/time_execution/backends/elasticsearch.py
@@ -11,7 +11,14 @@ logger = logging.getLogger(__name__)
 
 class ElasticsearchBackend(BaseMetricsBackend):
     def __init__(
-        self, hosts=None, index="metrics", doc_type="metric", index_pattern="{index}-{date:%Y.%m.%d}", *args, **kwargs
+        self,
+        hosts=None,
+        index="metrics",
+        doc_type="metric",
+        index_pattern="{index}-{date:%Y.%m.%d}",
+        create_index=True,
+        *args,
+        **kwargs,
     ):
         # Assign these in the backend as they are needed when writing metrics
         # to elasticsearch
@@ -22,15 +29,15 @@ class ElasticsearchBackend(BaseMetricsBackend):
         # setup the client
         self.client = Elasticsearch(hosts=hosts, *args, **kwargs)
 
-        # ensure the index is created
-        try:
-            self._setup_index()
-        except TransportError as exc:
-            logger.error("index setup error %r", exc)
-        try:
-            self._setup_mapping()
-        except TransportError as exc:
-            logger.error("mapping setup error %r", exc)
+        if create_index:
+            try:
+                self._setup_index()
+            except TransportError as exc:
+                logger.error("index setup error %r", exc)
+            try:
+                self._setup_mapping()
+            except TransportError as exc:
+                logger.error("mapping setup error %r", exc)
 
     def get_index(self):
         return self.index_pattern.format(index=self.index, date=datetime.now())


### PR DESCRIPTION
When access Elasticsearch is restricted and you can't create indexes (assuming the index for this backend has been setup outside of this package) you will want to skip the index creation steps which were always done when the ES backend was instantiated.